### PR TITLE
new end-point  "api/stats/status/count"  find Quantity of orders by status

### DIFF
--- a/src/main/java/cat/itacademy/proyectoerp/controller/StatsController.java
+++ b/src/main/java/cat/itacademy/proyectoerp/controller/StatsController.java
@@ -263,4 +263,28 @@ public class StatsController {
 		}
 		return map;
 	}
+	@PreAuthorize("hasRole('ADMIN')")
+	@GetMapping("/status/count")
+	public Map<String, Object> getCountOrderByStatus() throws Exception {		
+
+		HashMap<String, Object> map = new HashMap<>();
+		
+		try {
+			HashMap<String, Long> countOrderStatus = orderService.countOrdersByStatus();
+			
+		      if(!countOrderStatus.isEmpty()){
+		        map.put("success", "true");
+		  		map.put("message", "order list found");
+		  		map.put("Quantity of orders by status",countOrderStatus);
+		      } else{
+		        map.put("success", "true");
+		        map.put("message", "order list empty");		        
+		      }
+		    } catch (Exception e) {
+		      map.put("success", "false");
+		      map.put("message", "error: " + e.getMessage());
+		    }
+
+		return map;
+	}
 }

--- a/src/main/java/cat/itacademy/proyectoerp/domain/Order.java
+++ b/src/main/java/cat/itacademy/proyectoerp/domain/Order.java
@@ -101,7 +101,7 @@ public class Order  {
 	@PrePersist
 	public void prePersist() {
 		this.dateCreated = LocalDateTime.now();
-		this.status = OrderStatus.UNASSIGNED;
+		//this.status = OrderStatus.UNASSIGNED;
 	}
 	
 	//Getters & Setters

--- a/src/main/java/cat/itacademy/proyectoerp/repository/IOrderRepository.java
+++ b/src/main/java/cat/itacademy/proyectoerp/repository/IOrderRepository.java
@@ -33,6 +33,9 @@ public interface IOrderRepository extends JpaRepository<Order, UUID>{
           +"where (orders.status like 'COMPLETED') "	
           +" and (orders.date_created between :begin_date and :end_date) ", nativeQuery = true)
   double findProfitBetweenDates(LocalDateTime begin_date, LocalDateTime end_date);
+  
+  @Query(value = "select status from orders", nativeQuery = true)
+  List<String> findAllStatusOfOrders();
 
 }
  

--- a/src/main/java/cat/itacademy/proyectoerp/service/IOrderService.java
+++ b/src/main/java/cat/itacademy/proyectoerp/service/IOrderService.java
@@ -1,5 +1,6 @@
 package cat.itacademy.proyectoerp.service;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 
@@ -24,11 +25,12 @@ public interface IOrderService {
 	public void deleteOrder(UUID id);
 
 	public List<Order> findOrdersByStatus(OrderStatus status);
+	
+	public  HashMap<String, Long> countOrdersByStatus();		
 
 	public List<Order> findOrdersByClient(String id);
 	
-	public List<Order> findByEmployeeId(UUID employeeId);
-	
+	public List<Order> findByEmployeeId(UUID employeeId);	
 	
 	public List<TopEmployeeDTO> findAllTopTen(DatesTopEmployeePOJO topemployee);
 	

--- a/src/main/java/cat/itacademy/proyectoerp/service/OrderServiceImpl.java
+++ b/src/main/java/cat/itacademy/proyectoerp/service/OrderServiceImpl.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -306,6 +307,28 @@ public class OrderServiceImpl implements IOrderService{
 			if (profit== 0) throw new ArgumentNotFoundException("There are no completed orders for " +  new DateFormatSymbols().getMonths()[month-1] + " " + year);
 		}
 		return profit;
+	}
+
+	@Override
+	public HashMap<String, Long> countOrdersByStatus() {
+
+		HashMap<String, Long> map = new HashMap<>();				
+
+		List<String> statusOrders = orderRepository.findAllStatusOfOrders();
+
+		if (statusOrders.isEmpty()) {
+			throw new ArgumentNotFoundException("No orders found");
+		} else {
+			
+			long count = 0;
+			for (OrderStatus o : OrderStatus.values()) {
+				count = statusOrders.stream().filter(c -> (c.equals(o.name()))).count();
+				map.put(o.name(), count);
+				count = 0;
+			}
+		}
+
+		return map;
 	}
 
 	


### PR DESCRIPTION
1-Create a new querry (in IOrderRepository) to find a list of (String) status .
2-Add a new method " HashMap<String, Long> countOrdersByStatus();" in IOrderService.
3-Implement countOrdersByStatus() in OrderServiceImpl. 
           a-Find all the status in the orders
           b-Iterate de enum OrderStatus,
                Count and filter by name the list of status, with lambda expresion,
                 Put in a map the name and the quantity.
           c-Return the map
4-Create a function with the "end-point" api/stats/status/count
      Call  countOrdersByStatus() , put it in a map and send the map
5-comment on the pre-persist instruction "this.status = OrderStatus.UNASSIGNED;" if not all the status  will be "UNASSIGNED"