### PR TITLE
change response  to lower case and do testing, fix forgetfulness B-89

### DIFF
--- a/src/main/java/cat/itacademy/proyectoerp/service/OrderServiceImpl.java
+++ b/src/main/java/cat/itacademy/proyectoerp/service/OrderServiceImpl.java
@@ -314,7 +314,7 @@ public class OrderServiceImpl implements IOrderService{
 
 		HashMap<String, Long> map = new HashMap<>();				
 
-		List<String> statusOrders = orderRepository.findAllStatusOfOrders();
+		List<String> statusOrders = orderRepository.findAllStatusOfOrders().stream().filter(c-> c!=null).collect(Collectors.toList());
 
 		if (statusOrders.isEmpty()) {
 			throw new ArgumentNotFoundException("No orders found");
@@ -323,7 +323,7 @@ public class OrderServiceImpl implements IOrderService{
 			long count = 0;
 			for (OrderStatus o : OrderStatus.values()) {
 				count = statusOrders.stream().filter(c -> (c.equals(o.name()))).count();
-				map.put(o.name(), count);
+				map.put(o.name().toLowerCase(), count);
 				count = 0;
 			}
 		}

--- a/src/test/java/cat/itacademy/proyectoerp/StatsControllerIntegrationTest.java
+++ b/src/test/java/cat/itacademy/proyectoerp/StatsControllerIntegrationTest.java
@@ -301,6 +301,26 @@ public class StatsControllerIntegrationTest {
 				.andExpect(jsonPath("$.message",is("Total salaries for a month found")))
 				.andExpect(jsonPath("$.salaries", is(4166.6666666666667)));
 	}
+	
+	@Test
+	@DisplayName("Correct [GET] /api/stats/status")
+	public void RequestOrdersByStatus() throws Exception {
+
+		String accessToken = obtainAdminAccessToken();
+			
+		// request
+		mockMvc.perform(get("/api/stats/status")
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+				.accept(MediaType.APPLICATION_JSON_VALUE))
+		
+		// results
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success", is("true")))
+				.andExpect(jsonPath("$.message", is("order list found")))
+				.andExpect(jsonPath("$.orders_by_status.completed", is(3)))
+				.andExpect(jsonPath("$.orders_by_status.assigned", is(0)))
+				.andExpect(jsonPath("$.message", is("order list found")));
+	}
 
 	private String obtainAdminAccessToken() throws Exception {
 		JwtLogin jwtLogin = new JwtLogin("testAdmin@erp.com", "ReW9a0&+TP");


### PR DESCRIPTION
1-Change response endpoint "/api/stats/status" to lower case
2-testing  /api/stats/status  @Display "Correct [GET] /api/stats/status"
3-fix forgetfulness B-89. Avoid null in list  'statusOrders'.