### PR TITLE
B-94: Corrected "success" typo in "stats/employees/toptensales" response

### DIFF
--- a/src/main/java/cat/itacademy/proyectoerp/controller/StatsController.java
+++ b/src/main/java/cat/itacademy/proyectoerp/controller/StatsController.java
@@ -142,7 +142,7 @@ public class StatsController {
 			            map.put("message", "no employees or orders found between the dates");
 				  } 
 				  else {
-					  map.put("succes","true");
+					  map.put("success","true");
 					  map.put("message","top 10 employees found");
 					  map.put("employees", employeeList);
 				  }


### PR DESCRIPTION
**Issue:** B-94
**Title:** get stats/employees/toptensales typo
**Short Desc.:** "Succes" has two "s" at the end ;)

Corrected typo in word _succes_ --> succes**s** in file _src/main/java/cat/itacademy/proyectoerp/controller/StatsController.java_.