### PR TITLE
B-101: Disable JWT Security creating clients

### DIFF
--- a/src/main/java/cat/itacademy/proyectoerp/controller/UserController.java
+++ b/src/main/java/cat/itacademy/proyectoerp/controller/UserController.java
@@ -91,10 +91,12 @@ public class UserController {
 	/**
 	 * Method for create a new user and client.
 	 * 
+	 * It is not required to be authenticated to use this method. 
+	 * Opened access in issue B-101.
+	 * 
 	 * @param standard JSON with StandarRegistration data
 	 * @return Welcome String.
 	*/
-	@PreAuthorize("hasRole('ADMIN')")
 	@RequestMapping(value = "/users/clients", method = RequestMethod.POST)
 	public ResponseEntity<?> newUserAndClient(@Valid @RequestBody StandardRegistration standard) {
 		ClientDTO clientDTO;

--- a/src/main/java/cat/itacademy/proyectoerp/security/SecurityConfig.java
+++ b/src/main/java/cat/itacademy/proyectoerp/security/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 		http.cors().and().csrf().disable().authorizeRequests()
 				.antMatchers(HttpMethod.GET, "/api/products").permitAll()
 				.antMatchers(HttpMethod.POST, "/api/users").permitAll()
-				.antMatchers("/api/login", "/api/users/recoverpassword")
+				.antMatchers("/api/login", "/api/users/clients" ,"/api/users/recoverpassword")
 				.permitAll().anyRequest().authenticated().and()
 				// Exception control. 401 no authorized
 				.exceptionHandling().authenticationEntryPoint(jwtEntryPoint).and().sessionManagement()


### PR DESCRIPTION
**Issue:** B-101
**Title:** Disable JWT Security creating clients
**Short Desc.:** --

Objective is to allow a non registered user create a new user and client with the front end form.

It has been achieved by:
1) Adding end point (_/api/users/clients_) to the filter defined for _POST_ access in the general security configuration in _security/SecurityConfig.java_.
2) Removed the pre-condition for being a registered user and specific role defined in the method associated with the end point in the controller (_controller/UserController.java_).